### PR TITLE
Fix duplicate loader function call in playground store

### DIFF
--- a/apps/playground/src/app/ui/pages/user-resource/user-resource-store.provider.ts
+++ b/apps/playground/src/app/ui/pages/user-resource/user-resource-store.provider.ts
@@ -36,9 +36,6 @@ export const userStoreProvider = (() => {
         throw new Error(httpErr.message ?? 'Erro desconhecido');
       })
     )
-    .withLoaderFn((params: UserParams, api: UserApiService) =>
-      api.getUserById(params.id)
-    )
     .addDependency(UserApiService)
     // 4) TTL de 2 minutos (120000 ms)
     .withTtlMs(2 * 60 * 1000);


### PR DESCRIPTION
## Summary
- remove redundant `.withLoaderFn` call in UserResource store provider

## Testing
- `npx nx build apps/playground` *(fails: connect EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_683c122b3e7483309d4277e802d4745b