### PR TITLE
Add Global Store demo

### DIFF
--- a/apps/playground/src/app/app.config.ts
+++ b/apps/playground/src/app/app.config.ts
@@ -15,6 +15,7 @@ import { appFooter } from './layout/app.footer';
 import { appTopbar } from './layout/app.topbar';
 import { appLayout } from './layout/app.layout';
 import { userStoreProvider } from './ui/pages/user-resource/user-resource-store.provider';
+import { authGlobalStoreProvider } from './ui/pages/global-store-demo/auth-global-store.provider';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -40,6 +41,7 @@ export const appConfig: ApplicationConfig = {
       const config = inject(SMZ_UI_LAYOUT_CONFIG);
       config.hasClaim = () => true;
     }),
-    userStoreProvider
+    userStoreProvider,
+    authGlobalStoreProvider
   ],
 };

--- a/apps/playground/src/app/app.routes.ts
+++ b/apps/playground/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Route } from '@angular/router';
 import { AccessPageComponent, AppLayoutComponent, ErrorPageComponent, NotfoundPageComponent } from '@smz-ui/layout';
 import { HomePageComponent } from './ui/pages/home-page.component';
 import { UserResourceComponent } from './ui/pages/user-resource/user-resource.component';
+import { GlobalStoreDemoComponent } from './ui/pages/global-store-demo/global-store-demo.component';
 
 export const appRoutes: Route[] = [
   {
@@ -19,6 +20,7 @@ export const appRoutes: Route[] = [
         children: [
           { path: 'home', component: HomePageComponent, data: { title: 'Home' } },
           { path: 'user-resource', component: UserResourceComponent, data: { title: 'User Resource Store Demo' } },
+          { path: 'global-store', component: GlobalStoreDemoComponent, data: { title: 'Global Store Demo' } },
           { path: '', redirectTo: 'home', pathMatch: 'full' },
         ]
       },

--- a/apps/playground/src/app/smz-store/generic-global-store.ts
+++ b/apps/playground/src/app/smz-store/generic-global-store.ts
@@ -1,0 +1,31 @@
+import { GlobalStore } from './global-store';
+
+export class GenericGlobalStore<T> extends GlobalStore<T> {
+  private readonly _initialState: T;
+  private readonly _loaderFn: () => Promise<Partial<T>>;
+  private readonly _ttlMs: number;
+
+  constructor(options: {
+    initialState: T;
+    loaderFn: () => Promise<Partial<T>>;
+    ttlMs?: number;
+  }) {
+    super();
+    this._initialState = options.initialState;
+    this._loaderFn = options.loaderFn;
+    this._ttlMs = options.ttlMs ?? 0;
+  }
+
+  protected override getInitialState(): T {
+    return this._initialState;
+  }
+
+  protected override loadFromApi(): Promise<Partial<T>> {
+    return this._loaderFn();
+  }
+
+  protected override getTtlMs(): number {
+    return this._ttlMs;
+  }
+}
+

--- a/apps/playground/src/app/smz-store/global-store-builder.ts
+++ b/apps/playground/src/app/smz-store/global-store-builder.ts
@@ -1,0 +1,46 @@
+import { EnvironmentInjector, InjectionToken, Provider } from '@angular/core';
+import { GenericGlobalStore } from './generic-global-store';
+
+export class GlobalStoreBuilder<T> {
+  private _initialState!: T;
+  private _loaderFn!: (...deps: any[]) => Promise<Partial<T>>;
+  private _ttlMs = 0;
+
+  withInitialState(state: T): this {
+    this._initialState = state;
+    return this;
+  }
+
+  withLoaderFn(fn: (...deps: any[]) => Promise<Partial<T>>): this {
+    this._loaderFn = fn;
+    return this;
+  }
+
+  withTtlMs(ttlMs: number): this {
+    this._ttlMs = ttlMs;
+    return this;
+  }
+
+  addDependency(_dep: any): this {
+    return this;
+  }
+
+  buildProvider(token: InjectionToken<GenericGlobalStore<T>>, extraDeps: any[] = []): Provider {
+    const depsArray = [EnvironmentInjector, ...extraDeps];
+    return {
+      provide: token,
+      useFactory: (env: EnvironmentInjector, ...injectedDeps: any[]) => {
+        const loader = () => this._loaderFn(...injectedDeps);
+        const store = new GenericGlobalStore<T>({
+          initialState: this._initialState,
+          loaderFn: loader,
+          ttlMs: this._ttlMs,
+        });
+        void store.reload();
+        return store;
+      },
+      deps: depsArray,
+    };
+  }
+}
+

--- a/apps/playground/src/app/smz-store/global-store.ts
+++ b/apps/playground/src/app/smz-store/global-store.ts
@@ -1,0 +1,132 @@
+import {
+  inject,
+  Injectable,
+  Signal,
+  WritableSignal,
+  computed,
+  effect,
+  signal,
+} from '@angular/core';
+import { LoggingService, ScopedLogger } from '@smz-ui/layout';
+
+export type GlobalStoreStatus = 'idle' | 'loading' | 'resolved' | 'error';
+
+@Injectable({ providedIn: 'root' })
+export abstract class GlobalStore<T> {
+  protected readonly stateSignal: WritableSignal<T> = signal<T>(
+    this._deepFreeze(this.getInitialState())
+  );
+  protected readonly statusSignal: WritableSignal<GlobalStoreStatus> = signal<GlobalStoreStatus>('idle');
+  protected readonly errorSignal: WritableSignal<Error | null> = signal<Error | null>(null);
+
+  readonly state: Signal<T> = computed(() => this.stateSignal());
+  readonly status: Signal<GlobalStoreStatus> = computed(() => this.statusSignal());
+  readonly error: Signal<Error | null> = computed(() => this.errorSignal());
+  readonly isLoading = computed(() => this.status() === 'loading');
+  readonly isError = computed(() => this.status() === 'error');
+  readonly isResolved = computed(() => this.status() === 'resolved');
+
+  protected readonly loggingService = inject(LoggingService);
+  protected readonly logger: ScopedLogger = this.loggingService.scoped(
+    (this.constructor as { name: string }).name
+  );
+
+  private ttlTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastFetchTimestamp: number | null = null;
+
+  constructor() {
+    effect(() => {
+      const s = this.stateSignal();
+      this.logger.debug(`${this.constructor.name}: state updated →`, s);
+    });
+
+    effect(() => {
+      const st = this.statusSignal();
+      this.logger.debug(`${this.constructor.name}: status changed →`, st);
+    });
+
+    effect(() => {
+      if (this.isResolved()) {
+        this._scheduleTtlReload();
+      } else {
+        this._clearTtlTimer();
+      }
+    });
+  }
+
+  /** Valor inicial de estado */
+  protected abstract getInitialState(): T;
+  /** Função de carregamento opcional */
+  protected abstract loadFromApi(): Promise<Partial<T>>;
+  /** TTL opcional (ms) */
+  protected getTtlMs(): number {
+    return 0;
+  }
+
+  async reload(): Promise<void> {
+    this.logger.info(`${this.constructor.name}: reload()`);
+    this._clearTtlTimer();
+    this.statusSignal.set('loading');
+    this.errorSignal.set(null);
+    try {
+      const result = await this.loadFromApi();
+      this.updateState(result);
+      this.statusSignal.set('resolved');
+      this._updateLastFetch();
+    } catch (err) {
+      const wrapped = err instanceof Error ? err : new Error(String(err));
+      this.errorSignal.set(wrapped);
+      this.statusSignal.set('error');
+    }
+  }
+
+  updateState(partial: Partial<T>): void {
+    this.logger.info(`${this.constructor.name}: updateState`, partial);
+    this.stateSignal.update((s) => this._deepFreeze({ ...(s as any), ...partial }));
+  }
+
+  private _updateLastFetch(): void {
+    this.lastFetchTimestamp = Date.now();
+  }
+
+  private _scheduleTtlReload(): void {
+    const ttl = this.getTtlMs();
+    if (ttl <= 0) return;
+    if (this.ttlTimer) this._clearTtlTimer();
+    const elapsed = this.lastFetchTimestamp ? Date.now() - this.lastFetchTimestamp : Infinity;
+    const delayMs = ttl - elapsed;
+    if (delayMs <= 0) {
+      this.logger.info(`${this.constructor.name}: TTL expired, reloading immediately`);
+      void this.reload();
+    } else {
+      this.logger.debug(`${this.constructor.name}: scheduling reload in ${delayMs}ms (TTL)`);
+      this.ttlTimer = setTimeout(() => {
+        this.logger.info(`${this.constructor.name}: TTL reached, reloading`);
+        void this.reload();
+      }, delayMs);
+    }
+  }
+
+  private _clearTtlTimer(): void {
+    if (this.ttlTimer) {
+      clearTimeout(this.ttlTimer);
+      this.ttlTimer = null;
+    }
+  }
+
+  private _deepFreeze(obj: T): T {
+    if (obj === null || obj === undefined || typeof obj !== 'object') {
+      return obj;
+    }
+    const r = obj as Record<string, unknown>;
+    Object.freeze(r);
+    for (const k of Object.keys(r)) {
+      const val = r[k];
+      if (val && typeof val === 'object' && !Object.isFrozen(val)) {
+        this._deepFreeze(val as T);
+      }
+    }
+    return obj;
+  }
+}
+

--- a/apps/playground/src/app/ui/pages/global-store-demo/auth-global-store.provider.ts
+++ b/apps/playground/src/app/ui/pages/global-store-demo/auth-global-store.provider.ts
@@ -1,0 +1,17 @@
+import { InjectionToken } from '@angular/core';
+import { GlobalStoreBuilder } from '../../../smz-store/global-store-builder';
+import { GenericGlobalStore } from '../../../smz-store/generic-global-store';
+import { AuthState } from './auth.model';
+import { AuthApiService } from './auth.api';
+
+export const AUTH_GLOBAL_STORE_TOKEN = new InjectionToken<GenericGlobalStore<AuthState>>('AUTH_GLOBAL_STORE_TOKEN');
+
+export const authGlobalStoreProvider = (() => {
+  const builder = new GlobalStoreBuilder<AuthState>()
+    .withInitialState({ token: null, currentUser: null })
+    .withLoaderFn((api: AuthApiService) => api.fetchAuthData())
+    .addDependency(AuthApiService)
+    .withTtlMs(60 * 1000);
+
+  return builder.buildProvider(AUTH_GLOBAL_STORE_TOKEN, [AuthApiService]);
+})();

--- a/apps/playground/src/app/ui/pages/global-store-demo/auth.api.ts
+++ b/apps/playground/src/app/ui/pages/global-store-demo/auth.api.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { AuthState } from './auth.model';
+
+@Injectable({ providedIn: 'root' })
+export class AuthApiService {
+  async fetchAuthData(): Promise<Partial<AuthState>> {
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    return {
+      token: 'token-' + Math.random().toString(36).substring(2, 8),
+      currentUser: { id: 1, name: 'Demo User' },
+    };
+  }
+}

--- a/apps/playground/src/app/ui/pages/global-store-demo/auth.model.ts
+++ b/apps/playground/src/app/ui/pages/global-store-demo/auth.model.ts
@@ -1,0 +1,9 @@
+export interface UserInfo {
+  id: number;
+  name: string;
+}
+
+export interface AuthState {
+  token: string | null;
+  currentUser: UserInfo | null;
+}

--- a/apps/playground/src/app/ui/pages/global-store-demo/global-store-demo.component.ts
+++ b/apps/playground/src/app/ui/pages/global-store-demo/global-store-demo.component.ts
@@ -1,0 +1,47 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ButtonModule } from 'primeng/button';
+import { GenericGlobalStore } from '../../../smz-store/generic-global-store';
+import { AUTH_GLOBAL_STORE_TOKEN } from './auth-global-store.provider';
+import { AuthState } from './auth.model';
+
+@Component({
+  selector: 'app-global-store-demo',
+  standalone: true,
+  imports: [CommonModule, ButtonModule],
+  host: { class: 'flex flex-col gap-4' },
+  template: `
+    <div class="flex flex-col gap-2">
+      <div class="text-3xl font-bold">Global Store Demo</div>
+      <div>Status: {{ store.status() }}</div>
+    </div>
+
+    <div class="flex gap-2">
+      <button pButton type="button" icon="pi pi-refresh" (click)="store.reload()">Reload</button>
+      <button pButton type="button" icon="pi pi-times" severity="danger" (click)="clear()">Clear</button>
+    </div>
+
+    @if (store.isLoading()) {
+      <p>Loading authentication...</p>
+    }
+
+    @if (store.isResolved()) {
+      @let data = store.state();
+      <div class="flex flex-col gap-2 bg-gray-200 text-gray-800 p-2 rounded-md">
+        <div>Token: {{ data.token }}</div>
+        <div>User: {{ data.currentUser?.name }}</div>
+      </div>
+    }
+
+    @if (store.isError()) {
+      <div class="text-red-500">Error: {{ store.error()?.message }}</div>
+    }
+  `
+})
+export class GlobalStoreDemoComponent {
+  readonly store: GenericGlobalStore<AuthState> = inject(AUTH_GLOBAL_STORE_TOKEN);
+
+  clear() {
+    this.store.updateState({ token: null, currentUser: null });
+  }
+}


### PR DESCRIPTION
## Summary
- demonstrate GlobalStore with a simple auth demo
- register the global store provider in the playground
- add navigation route for Global Store demo

## Testing
- `npx nx lint playground` *(fails: EHOSTUNREACH)*
- `npx nx test playground` *(fails: EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_683c11a0ac888330b1d5f77e581b54fd