### PR TITLE
Add cleanup logic for FeatureStore

### DIFF
--- a/apps/playground/src/app/smz-store/feature-store-builder.ts
+++ b/apps/playground/src/app/smz-store/feature-store-builder.ts
@@ -1,4 +1,4 @@
-import { EnvironmentInjector, InjectionToken, Provider } from '@angular/core';
+import { DestroyRef, EnvironmentInjector, InjectionToken, Provider } from '@angular/core';
 import { GenericFeatureStore } from './generic-feature-store';
 
 export class FeatureStoreBuilder<T> {
@@ -26,16 +26,17 @@ export class FeatureStoreBuilder<T> {
   }
 
   buildProvider(token: InjectionToken<GenericFeatureStore<T>>, extraDeps: any[] = []): Provider {
-    const depsArray = [EnvironmentInjector, ...extraDeps];
+    const depsArray = [EnvironmentInjector, DestroyRef, ...extraDeps];
     return {
       provide: token,
-      useFactory: (env: EnvironmentInjector, ...injectedDeps: any[]) => {
+      useFactory: (env: EnvironmentInjector, destroyRef: DestroyRef, ...injectedDeps: any[]) => {
         const loader = () => this._loaderFn(...injectedDeps);
         const store = new GenericFeatureStore<T>({
           initialState: this._initialState,
           loaderFn: loader,
           ttlMs: this._ttlMs,
         });
+        destroyRef.onDestroy(() => store.ngOnDestroy());
         void store.reload();
         return store;
       },

--- a/apps/playground/src/app/smz-store/feature-store.ts
+++ b/apps/playground/src/app/smz-store/feature-store.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { DestroyRef, Injectable, OnDestroy, inject } from '@angular/core';
 import { GlobalStore } from './global-store';
 
 /**
@@ -6,4 +6,15 @@ import { GlobalStore } from './global-store';
  * injector. It exists only while the feature that provided it is active.
  */
 @Injectable()
-export abstract class FeatureStore<T> extends GlobalStore<T> {}
+export abstract class FeatureStore<T> extends GlobalStore<T> implements OnDestroy {
+  private readonly destroyRef = inject(DestroyRef);
+
+  constructor() {
+    super();
+    this.destroyRef.onDestroy(() => this.ngOnDestroy());
+  }
+
+  ngOnDestroy(): void {
+    (this as any)._clearTtlTimer?.();
+  }
+}


### PR DESCRIPTION
## Summary
- ensure FeatureStore cleans TTL timer when provider is destroyed
- register cleanup in FeatureStoreBuilder so it runs even for scoped providers

## Testing
- `npx tsc -p tsconfig.json` *(fails: npm warn Unknown env config; no output)*
- `npx nx lint` *(fails: command not found/cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_683c1b5801048330991a117cc9bddfe6