### PR TITLE
Handle FeatureStore TTL automatically

### DIFF
--- a/apps/playground/src/app/smz-store/feature-store-builder.ts
+++ b/apps/playground/src/app/smz-store/feature-store-builder.ts
@@ -1,4 +1,6 @@
-import { EnvironmentInjector, InjectionToken, Provider } from '@angular/core';
+import { DestroyRef, EnvironmentInjector, InjectionToken, Provider } from '@angular/core';
+import { NavigationEnd, NavigationStart, Router } from '@angular/router';
+import { filter } from 'rxjs/operators';
 import { GenericFeatureStore } from './generic-feature-store';
 
 export class FeatureStoreBuilder<T> {
@@ -26,15 +28,39 @@ export class FeatureStoreBuilder<T> {
   }
 
   buildProvider(token: InjectionToken<GenericFeatureStore<T>>, extraDeps: any[] = []): Provider {
-    const depsArray = [EnvironmentInjector, ...extraDeps];
+    const depsArray = [EnvironmentInjector, DestroyRef, Router, ...extraDeps];
     return {
       provide: token,
-      useFactory: (env: EnvironmentInjector, ...injectedDeps: any[]) => {
+      useFactory: (
+        env: EnvironmentInjector,
+        destroyRef: DestroyRef,
+        router: Router,
+        ...injectedDeps: any[]
+      ) => {
         const loader = () => this._loaderFn(...injectedDeps);
         const store = new GenericFeatureStore<T>({
           initialState: this._initialState,
           loaderFn: loader,
           ttlMs: this._ttlMs,
+        });
+        const initialUrl = router.url;
+        const sub = router.events
+          .pipe(filter((ev) => ev instanceof NavigationStart || ev instanceof NavigationEnd))
+          .subscribe((ev) => {
+            if (ev instanceof NavigationStart) {
+              store.pauseTtl();
+            } else if (ev instanceof NavigationEnd) {
+              if (router.url === initialUrl) {
+                store.resumeTtl();
+              } else {
+                store.pauseTtl();
+              }
+            }
+          });
+
+        destroyRef.onDestroy(() => {
+          sub.unsubscribe();
+          store.ngOnDestroy();
         });
         void store.reload();
         return store;

--- a/apps/playground/src/app/smz-store/feature-store.ts
+++ b/apps/playground/src/app/smz-store/feature-store.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { DestroyRef, Injectable, OnDestroy, inject } from '@angular/core';
 import { GlobalStore } from './global-store';
 
 /**
@@ -6,4 +6,26 @@ import { GlobalStore } from './global-store';
  * injector. It exists only while the feature that provided it is active.
  */
 @Injectable()
-export abstract class FeatureStore<T> extends GlobalStore<T> {}
+export abstract class FeatureStore<T> extends GlobalStore<T> implements OnDestroy {
+  private readonly destroyRef = inject(DestroyRef);
+  private _ttlPaused = false;
+
+  constructor() {
+    super();
+    this.destroyRef.onDestroy(() => this.ngOnDestroy());
+  }
+
+  ngOnDestroy(): void {
+    (this as any)._clearTtlTimer?.();
+  }
+
+  pauseTtl(): void {
+    this._ttlPaused = true;
+    (this as any)._clearTtlTimer?.();
+  }
+
+  resumeTtl(): void {
+    this._ttlPaused = false;
+    (this as any)._scheduleTtlReload?.();
+  }
+}


### PR DESCRIPTION
## Summary
- add TTL pause and resume methods to `FeatureStore`
- watch router events inside `FeatureStoreBuilder` to pause TTL when leaving the route

## Testing
- `npx nx test` *(fails: EHOSTUNREACH)*
- `npx nx lint` *(fails: EHOSTUNREACH)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_b_683c1b5801048330991a117cc9bddfe6