### PR TITLE
Implement custom logging scope names

### DIFF
--- a/apps/playground/src/app/smz-store/feature-store-builder.ts
+++ b/apps/playground/src/app/smz-store/feature-store-builder.ts
@@ -7,6 +7,7 @@ export class FeatureStoreBuilder<T> {
   private _initialState!: T;
   private _loaderFn!: (...deps: any[]) => Promise<Partial<T>>;
   private _ttlMs = 0;
+  private _name!: string;
 
   withInitialState(state: T): this {
     this._initialState = state;
@@ -15,6 +16,11 @@ export class FeatureStoreBuilder<T> {
 
   withLoaderFn(fn: (...deps: any[]) => Promise<Partial<T>>): this {
     this._loaderFn = fn;
+    return this;
+  }
+
+  withName(name: string): this {
+    this._name = name;
     return this;
   }
 
@@ -40,6 +46,7 @@ export class FeatureStoreBuilder<T> {
 
         const loader = () => this._loaderFn(...injectedDeps);
         const store = new GenericFeatureStore<T>({
+          scopeName: this._name ?? (token as any).desc ?? token.toString(),
           initialState: this._initialState,
           loaderFn: loader,
           ttlMs: this._ttlMs,

--- a/apps/playground/src/app/smz-store/feature-store.ts
+++ b/apps/playground/src/app/smz-store/feature-store.ts
@@ -10,8 +10,8 @@ export abstract class FeatureStore<T> extends GlobalStore<T> implements OnDestro
   private readonly destroyRef = inject(DestroyRef);
   private _ttlPaused = false;
 
-  constructor() {
-    super();
+  constructor(scopeName?: string) {
+    super(scopeName);
     this.destroyRef.onDestroy(() => this.ngOnDestroy());
   }
 

--- a/apps/playground/src/app/smz-store/generic-feature-store.ts
+++ b/apps/playground/src/app/smz-store/generic-feature-store.ts
@@ -5,8 +5,8 @@ export class GenericFeatureStore<T> extends FeatureStore<T> {
   private readonly _loaderFn: () => Promise<Partial<T>>;
   private readonly _ttlMs: number;
 
-  constructor(options: { initialState: T; loaderFn: () => Promise<Partial<T>>; ttlMs?: number }) {
-    super();
+  constructor(options: { scopeName: string; initialState: T; loaderFn: () => Promise<Partial<T>>; ttlMs?: number }) {
+    super(options.scopeName);
     this._initialState = options.initialState;
     this._loaderFn = options.loaderFn;
     this._ttlMs = options.ttlMs ?? 0;

--- a/apps/playground/src/app/smz-store/generic-global-store.ts
+++ b/apps/playground/src/app/smz-store/generic-global-store.ts
@@ -6,11 +6,12 @@ export class GenericGlobalStore<T> extends GlobalStore<T> {
   private readonly _ttlMs: number;
 
   constructor(options: {
+    scopeName: string;
     initialState: T;
     loaderFn: () => Promise<Partial<T>>;
     ttlMs?: number;
   }) {
-    super();
+    super(options.scopeName);
     this._initialState = options.initialState;
     this._loaderFn = options.loaderFn;
     this._ttlMs = options.ttlMs ?? 0;

--- a/apps/playground/src/app/smz-store/generic-resource-store.ts
+++ b/apps/playground/src/app/smz-store/generic-resource-store.ts
@@ -23,13 +23,14 @@ export class GenericResourceStore<T, P extends Record<string, any> | void>
   private readonly _ttlMs: number;
 
   constructor(options: {
+    scopeName: string;
     initialParams: P;
     defaultValue: T;
     loaderFn: (params: P) => Promise<T>;
     ttlMs?: number;
   }) {
     // Chama o construtor de ResourceStore (que já configura sinais, efeitos e logger)
-    super();
+    super(options.scopeName);
     this._initialParams = options.initialParams;
     this._defaultValue = options.defaultValue;
     this._loaderFn = options.loaderFn;

--- a/apps/playground/src/app/smz-store/global-store-builder.ts
+++ b/apps/playground/src/app/smz-store/global-store-builder.ts
@@ -5,6 +5,7 @@ export class GlobalStoreBuilder<T> {
   private _initialState!: T;
   private _loaderFn!: (...deps: any[]) => Promise<Partial<T>>;
   private _ttlMs = 0;
+  private _name!: string;
 
   withInitialState(state: T): this {
     this._initialState = state;
@@ -13,6 +14,11 @@ export class GlobalStoreBuilder<T> {
 
   withLoaderFn(fn: (...deps: any[]) => Promise<Partial<T>>): this {
     this._loaderFn = fn;
+    return this;
+  }
+
+  withName(name: string): this {
+    this._name = name;
     return this;
   }
 
@@ -32,6 +38,7 @@ export class GlobalStoreBuilder<T> {
       useFactory: (env: EnvironmentInjector, ...injectedDeps: any[]) => {
         const loader = () => this._loaderFn(...injectedDeps);
         const store = new GenericGlobalStore<T>({
+          scopeName: this._name ?? (token as any).desc ?? token.toString(),
           initialState: this._initialState,
           loaderFn: loader,
           ttlMs: this._ttlMs,

--- a/apps/playground/src/app/smz-store/global-store.ts
+++ b/apps/playground/src/app/smz-store/global-store.ts
@@ -29,14 +29,15 @@ export abstract class GlobalStore<T> {
   readonly isResolved = computed(() => this.status() === 'resolved');
 
   protected readonly loggingService = inject(LoggingService);
-  protected readonly logger: ScopedLogger = this.loggingService.scoped(
-    (this.constructor as { name: string }).name
-  );
+  protected logger: ScopedLogger;
 
   private ttlTimer: ReturnType<typeof setTimeout> | null = null;
   private lastFetchTimestamp: number | null = null;
 
-  constructor() {
+  constructor(scopeName?: string) {
+    this.logger = this.loggingService.scoped(
+      scopeName ?? (this.constructor as { name: string }).name
+    );
     effect(() => {
       const s = this.stateSignal();
       this.logger.debug(`state updated →`, s);

--- a/apps/playground/src/app/smz-store/resource-store-builder.ts
+++ b/apps/playground/src/app/smz-store/resource-store-builder.ts
@@ -14,6 +14,7 @@ export class ResourceStoreBuilder<
   private _defaultValue!: T;
   private _loaderFn!: (params: P, ...deps: any[]) => Promise<T>;
   private _ttlMs = 0;
+  private _name!: string;
 
   /**
    * Configura os parâmetros iniciais (P).
@@ -38,6 +39,11 @@ export class ResourceStoreBuilder<
    */
   withLoaderFn(loaderFn: (params: P, ...deps: any[]) => Promise<T>): this {
     this._loaderFn = loaderFn;
+    return this;
+  }
+
+  withName(name: string): this {
+    this._name = name;
     return this;
   }
 
@@ -85,6 +91,7 @@ export class ResourceStoreBuilder<
 
         // Instancia o GenericResourceStore
         const store = new GenericResourceStore<T, P>({
+          scopeName: this._name ?? (token as any).desc ?? token.toString(),
           initialParams: this._initialParams,
           defaultValue: this._defaultValue,
           loaderFn: adaptedLoader,

--- a/apps/playground/src/app/smz-store/resource-store.ts
+++ b/apps/playground/src/app/smz-store/resource-store.ts
@@ -106,8 +106,7 @@ export abstract class ResourceStore<T, P extends Record<string, any> | void> {
 
   /** LoggingService e logger */
   protected readonly loggingService = inject(LoggingService);
-  protected readonly logger: ScopedLogger =
-    this.loggingService.scoped((this.constructor as { name: string }).name);
+  protected logger: ScopedLogger;
 
   /** Timestamp (ms) do último fetch bem-sucedido */
   private lastFetchTimestamp: number | null = null;
@@ -115,7 +114,10 @@ export abstract class ResourceStore<T, P extends Record<string, any> | void> {
   /** Timer de TTL (se houver) */
   private ttlTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor() {
+  constructor(scopeName?: string) {
+    this.logger = this.loggingService.scoped(
+      scopeName ?? (this.constructor as { name: string }).name
+    );
     // 5) Logs automáticos sobre valueRaw
     effect(() => {
       const v = this.valueRaw();

--- a/apps/playground/src/app/ui/pages/feature-store/counter-feature-store.provider.ts
+++ b/apps/playground/src/app/ui/pages/feature-store/counter-feature-store.provider.ts
@@ -15,7 +15,8 @@ export const counterFeatureStoreProvider = (() => {
       // Simulate async fetch of a random starting count
       return { count: Math.floor(Math.random() * 10) };
     })
-    .withTtlMs(5000);
+    .withTtlMs(5000)
+    .withName('CounterFeatureStore');
 
   return builder.buildProvider(COUNTER_FEATURE_STORE_TOKEN);
 })();

--- a/apps/playground/src/app/ui/pages/global-store-demo/auth-global-store.provider.ts
+++ b/apps/playground/src/app/ui/pages/global-store-demo/auth-global-store.provider.ts
@@ -11,7 +11,8 @@ export const authGlobalStoreProvider = (() => {
     .withInitialState({ token: null, currentUser: null })
     .withLoaderFn((api: AuthApiService) => api.fetchAuthData())
     .addDependency(AuthApiService)
-    .withTtlMs(3000);
+    .withTtlMs(3000)
+    .withName('AuthGlobalStore');
 
   return builder.buildProvider(AUTH_GLOBAL_STORE_TOKEN, [AuthApiService]);
 })();

--- a/apps/playground/src/app/ui/pages/user-resource/user-resource-store.provider.ts
+++ b/apps/playground/src/app/ui/pages/user-resource/user-resource-store.provider.ts
@@ -38,7 +38,8 @@ export const userStoreProvider = (() => {
     )
     .addDependency(UserApiService)
     // 4) TTL de 2 minutos (120000 ms)
-    .withTtlMs(5000);
+    .withTtlMs(5000)
+    .withName('UserResourceStore');
 
   // Registramos o provider, informando que UserApiService será injetado como dependência
   return builder.buildProvider(USER_RESOURCE_STORE_TOKEN, [UserApiService]);


### PR DESCRIPTION
## Summary
- allow passing a scope name to `GlobalStore`, `FeatureStore` and `ResourceStore`
- propagate the scope name through generic stores and builders
- expose `withName` in builders
- set descriptive store names in playground providers

## Testing
- `npx nx test` *(fails: connect EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_683c36bb27c08330b0d519b72b0ce015