### PR TITLE
Setup Karma for Nx libs

### DIFF
--- a/libs/smz-core/karma.conf.js
+++ b/libs/smz-core/karma.conf.js
@@ -1,0 +1,25 @@
+const { join } = require('path');
+
+module.exports = function (config) {
+  config.set({
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma'),
+    ],
+    client: {
+      jasmine: {},
+      clearContext: false,
+    },
+    coverageReporter: {
+      dir: join(__dirname, '../../coverage/smz-core'),
+      subdir: '.',
+      reporters: [{ type: 'html' }, { type: 'text-summary' }],
+    },
+    browsers: ['ChromeHeadless'],
+    reporters: ['progress', 'kjhtml'],
+  });
+};

--- a/libs/smz-core/project.json
+++ b/libs/smz-core/project.json
@@ -37,5 +37,15 @@
     "lint": {
       "executor": "@nx/eslint:lint"
     }
+    ,
+    "test": {
+      "executor": "@angular-devkit/build-angular:karma",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "main": "libs/smz-core/src/test.ts",
+        "tsConfig": "libs/smz-core/tsconfig.spec.json",
+        "karmaConfig": "libs/smz-core/karma.conf.js"
+      }
+    }
   }
 }

--- a/libs/smz-core/src/lib/core.spec.ts
+++ b/libs/smz-core/src/lib/core.spec.ts
@@ -1,0 +1,5 @@
+describe('@smz-ui/core', () => {
+  it('should be true', () => {
+    expect(true).toBeTrue();
+  });
+});

--- a/libs/smz-core/src/test.ts
+++ b/libs/smz-core/src/test.ts
@@ -1,0 +1,8 @@
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);

--- a/libs/smz-core/tsconfig.spec.json
+++ b/libs/smz-core/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["jasmine", "node"]
+  },
+  "files": ["src/test.ts"],
+  "include": ["**/*.spec.ts", "**/*.d.ts"]
+}

--- a/libs/smz-forms/karma.conf.js
+++ b/libs/smz-forms/karma.conf.js
@@ -1,0 +1,25 @@
+const { join } = require('path');
+
+module.exports = function (config) {
+  config.set({
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma'),
+    ],
+    client: {
+      jasmine: {},
+      clearContext: false,
+    },
+    coverageReporter: {
+      dir: join(__dirname, '../../coverage/smz-forms'),
+      subdir: '.',
+      reporters: [{ type: 'html' }, { type: 'text-summary' }],
+    },
+    browsers: ['ChromeHeadless'],
+    reporters: ['progress', 'kjhtml'],
+  });
+};

--- a/libs/smz-forms/project.json
+++ b/libs/smz-forms/project.json
@@ -43,5 +43,15 @@
     "lint": {
       "executor": "@nx/eslint:lint"
     }
+    ,
+    "test": {
+      "executor": "@angular-devkit/build-angular:karma",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "main": "libs/smz-forms/src/test.ts",
+        "tsConfig": "libs/smz-forms/tsconfig.spec.json",
+        "karmaConfig": "libs/smz-forms/karma.conf.js"
+      }
+    }
   }
 }

--- a/libs/smz-forms/src/lib/forms.spec.ts
+++ b/libs/smz-forms/src/lib/forms.spec.ts
@@ -1,0 +1,5 @@
+describe('@smz-ui/forms', () => {
+  it('should be true', () => {
+    expect(true).toBeTrue();
+  });
+});

--- a/libs/smz-forms/src/test.ts
+++ b/libs/smz-forms/src/test.ts
@@ -1,0 +1,8 @@
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);

--- a/libs/smz-forms/tsconfig.spec.json
+++ b/libs/smz-forms/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["jasmine", "node"]
+  },
+  "files": ["src/test.ts"],
+  "include": ["**/*.spec.ts", "**/*.d.ts"]
+}

--- a/libs/smz-layout/karma.conf.js
+++ b/libs/smz-layout/karma.conf.js
@@ -1,0 +1,25 @@
+const { join } = require('path');
+
+module.exports = function (config) {
+  config.set({
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma'),
+    ],
+    client: {
+      jasmine: {},
+      clearContext: false,
+    },
+    coverageReporter: {
+      dir: join(__dirname, '../../coverage/smz-layout'),
+      subdir: '.',
+      reporters: [{ type: 'html' }, { type: 'text-summary' }],
+    },
+    browsers: ['ChromeHeadless'],
+    reporters: ['progress', 'kjhtml'],
+  });
+};

--- a/libs/smz-layout/project.json
+++ b/libs/smz-layout/project.json
@@ -43,5 +43,15 @@
     "lint": {
       "executor": "@nx/eslint:lint"
     }
+    ,
+    "test": {
+      "executor": "@angular-devkit/build-angular:karma",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "main": "libs/smz-layout/src/test.ts",
+        "tsConfig": "libs/smz-layout/tsconfig.spec.json",
+        "karmaConfig": "libs/smz-layout/karma.conf.js"
+      }
+    }
   }
 }

--- a/libs/smz-layout/src/lib/layout.spec.ts
+++ b/libs/smz-layout/src/lib/layout.spec.ts
@@ -1,0 +1,5 @@
+describe('@smz-ui/layout', () => {
+  it('should be true', () => {
+    expect(true).toBeTrue();
+  });
+});

--- a/libs/smz-layout/src/test.ts
+++ b/libs/smz-layout/src/test.ts
@@ -1,0 +1,8 @@
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);

--- a/libs/smz-layout/tsconfig.spec.json
+++ b/libs/smz-layout/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["jasmine", "node"]
+  },
+  "files": ["src/test.ts"],
+  "include": ["**/*.spec.ts", "**/*.d.ts"]
+}

--- a/libs/smz-store/karma.conf.js
+++ b/libs/smz-store/karma.conf.js
@@ -1,0 +1,25 @@
+const { join } = require('path');
+
+module.exports = function (config) {
+  config.set({
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma'),
+    ],
+    client: {
+      jasmine: {},
+      clearContext: false,
+    },
+    coverageReporter: {
+      dir: join(__dirname, '../../coverage/smz-store'),
+      subdir: '.',
+      reporters: [{ type: 'html' }, { type: 'text-summary' }],
+    },
+    browsers: ['ChromeHeadless'],
+    reporters: ['progress', 'kjhtml'],
+  });
+};

--- a/libs/smz-store/project.json
+++ b/libs/smz-store/project.json
@@ -43,5 +43,15 @@
     "lint": {
       "executor": "@nx/eslint:lint"
     }
+    ,
+    "test": {
+      "executor": "@angular-devkit/build-angular:karma",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "main": "libs/smz-store/src/test.ts",
+        "tsConfig": "libs/smz-store/tsconfig.spec.json",
+        "karmaConfig": "libs/smz-store/karma.conf.js"
+      }
+    }
   }
 }

--- a/libs/smz-store/src/lib/store.spec.ts
+++ b/libs/smz-store/src/lib/store.spec.ts
@@ -1,0 +1,5 @@
+describe('@smz-ui/store', () => {
+  it('should be true', () => {
+    expect(true).toBeTrue();
+  });
+});

--- a/libs/smz-store/src/test.ts
+++ b/libs/smz-store/src/test.ts
@@ -1,0 +1,8 @@
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);

--- a/libs/smz-store/tsconfig.spec.json
+++ b/libs/smz-store/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["jasmine", "node"]
+  },
+  "files": ["src/test.ts"],
+  "include": ["**/*.spec.ts", "**/*.d.ts"]
+}


### PR DESCRIPTION
## Summary
- add Karma config and tsconfig.spec to all libs
- add basic spec files per lib
- wire up `test` targets in project.json

## Testing
- `npm test` *(fails: nx not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d4a05f1488330acd504a72edf2209