### PR TITLE
Add Albums CRUD demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,9 @@ export const postsCrudStoreProvider = new FeatureStoreBuilder<{ posts: Post[] }>
   })
   .buildProvider(POSTS_CRUD_STORE_TOKEN);
 ```
+
+### Albums CRUD Demo
+
+The `albums-crud` route showcases another simple CRUD using `GenericFeatureStore`.
+It follows the same pattern as the posts demo but manages albums retrieved from
+`https://jsonplaceholder.typicode.com/albums`.

--- a/apps/playground/src/app/app.routes.ts
+++ b/apps/playground/src/app/app.routes.ts
@@ -8,6 +8,8 @@ import { counterFeature1StoreProvider } from './ui/pages/feature-store/counter-f
 import { GlobalStoreDemoComponent } from './ui/pages/global-store-demo/global-store-demo.component';
 import { PostsCrudComponent } from './ui/pages/posts-crud/posts-crud.component';
 import { postsCrudStoreProvider } from './ui/pages/posts-crud/posts-crud-store.provider';
+import { AlbumsCrudComponent } from './ui/pages/albums-crud/albums-crud.component';
+import { albumsCrudStoreProvider } from './ui/pages/albums-crud/albums-crud-store.provider';
 
 export const appRoutes: Route[] = [
   {
@@ -42,6 +44,12 @@ export const appRoutes: Route[] = [
             component: PostsCrudComponent,
             data: { title: 'Posts CRUD Demo' },
             providers: [postsCrudStoreProvider],
+          },
+          {
+            path: 'albums-crud',
+            component: AlbumsCrudComponent,
+            data: { title: 'Albums CRUD Demo' },
+            providers: [albumsCrudStoreProvider],
           },
           { path: 'global-store', component: GlobalStoreDemoComponent, data: { title: 'Global Store Demo' } },
           { path: '', redirectTo: 'home', pathMatch: 'full' },

--- a/apps/playground/src/app/layout/static-data.ts
+++ b/apps/playground/src/app/layout/static-data.ts
@@ -10,6 +10,7 @@ export const INITIAL_SIDEBAR: MenuItem[] = [
             { label: 'Feature Store Demo 2 (Provided in the Component)', icon: 'pi pi-fw pi-star', routerLink: ['/feature-store-2'] },
             { label: 'Global Store Demo', icon: 'pi pi-fw pi-database', routerLink: ['/global-store'] },
             { label: 'Posts CRUD Demo', icon: 'pi pi-fw pi-database', routerLink: ['/posts-crud'] },
+            { label: 'Albums CRUD Demo', icon: 'pi pi-fw pi-database', routerLink: ['/albums-crud'] },
         ]
     }
 ]

--- a/apps/playground/src/app/ui/pages/albums-crud/album.api.ts
+++ b/apps/playground/src/app/ui/pages/albums-crud/album.api.ts
@@ -1,0 +1,25 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { Album } from './album.model';
+
+@Injectable({ providedIn: 'root' })
+export class AlbumApiService {
+  constructor(private http: HttpClient) {}
+
+  getAlbums() {
+    return firstValueFrom(this.http.get<Album[]>('https://jsonplaceholder.typicode.com/albums'));
+  }
+
+  createAlbum(album: Omit<Album, 'id'>) {
+    return firstValueFrom(this.http.post<Album>('https://jsonplaceholder.typicode.com/albums', album));
+  }
+
+  updateAlbum(album: Album) {
+    return firstValueFrom(this.http.put<Album>(`https://jsonplaceholder.typicode.com/albums/${album.id}`, album));
+  }
+
+  deleteAlbum(id: number) {
+    return firstValueFrom(this.http.delete<void>(`https://jsonplaceholder.typicode.com/albums/${id}`));
+  }
+}

--- a/apps/playground/src/app/ui/pages/albums-crud/album.model.ts
+++ b/apps/playground/src/app/ui/pages/albums-crud/album.model.ts
@@ -1,0 +1,4 @@
+export interface Album {
+  id: number;
+  title: string;
+}

--- a/apps/playground/src/app/ui/pages/albums-crud/albums-crud-store.provider.ts
+++ b/apps/playground/src/app/ui/pages/albums-crud/albums-crud-store.provider.ts
@@ -1,0 +1,37 @@
+import { InjectionToken } from '@angular/core';
+import { FeatureStoreBuilder, GenericFeatureStore } from '@smz-ui/store';
+import { Album } from './album.model';
+import { AlbumApiService } from './album.api';
+
+interface AlbumsCrudState {
+  albums: Album[];
+}
+
+export interface AlbumsCrudStore extends GenericFeatureStore<AlbumsCrudState> {
+  createAlbum(album: Omit<Album, 'id'>): Promise<void>;
+  updateAlbum(album: Album): Promise<void>;
+  deleteAlbum(id: number): Promise<void>;
+}
+
+const albumsCrudStoreBuilder = new FeatureStoreBuilder<AlbumsCrudState, AlbumsCrudStore>()
+  .withInitialState({ albums: [] })
+  .withLoaderFn(async (api: AlbumApiService) => ({ albums: await api.getAlbums() }))
+  .addDependency(AlbumApiService)
+  .withAction('createAlbum', (store: AlbumsCrudStore, api: AlbumApiService) => async (album: Omit<Album, 'id'>) => {
+    const created = await api.createAlbum(album);
+    store.updateState({ albums: [...store.state().albums, created] });
+  })
+  .withAction('updateAlbum', (store: AlbumsCrudStore, api: AlbumApiService) => async (album: Album) => {
+    const updated = await api.updateAlbum(album);
+    store.updateState({
+      albums: store.state().albums.map((a) => (a.id === updated.id ? updated : a)),
+    });
+  })
+  .withAction('deleteAlbum', (store: AlbumsCrudStore, api: AlbumApiService) => async (id: number) => {
+    await api.deleteAlbum(id);
+    store.updateState({ albums: store.state().albums.filter((a) => a.id !== id) });
+  });
+
+export const ALBUMS_CRUD_STORE_TOKEN = new InjectionToken<AlbumsCrudStore>('ALBUMS_CRUD_STORE_TOKEN');
+
+export const albumsCrudStoreProvider = albumsCrudStoreBuilder.buildProvider(ALBUMS_CRUD_STORE_TOKEN);

--- a/apps/playground/src/app/ui/pages/albums-crud/albums-crud.component.ts
+++ b/apps/playground/src/app/ui/pages/albums-crud/albums-crud.component.ts
@@ -1,0 +1,67 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ButtonModule } from 'primeng/button';
+import { AlbumsCrudStore, ALBUMS_CRUD_STORE_TOKEN } from './albums-crud-store.provider';
+import { Album } from './album.model';
+
+@Component({
+  selector: 'app-albums-crud',
+  standalone: true,
+  imports: [CommonModule, FormsModule, ButtonModule],
+  host: { class: 'flex flex-col gap-4' },
+  template: `
+    <div class="flex flex-col gap-2">
+      <div class="text-3xl font-bold">Albums CRUD Demo</div>
+      <div>Status: {{ store.status() }}</div>
+    </div>
+
+    <form class="flex flex-col gap-2" (ngSubmit)="addAlbum()">
+      <input class="border p-1" type="text" placeholder="Title" [(ngModel)]="newTitle" name="title" />
+      <button pButton type="submit" label="Create Album"></button>
+    </form>
+
+    <div class="flex gap-2">
+      <button pButton type="button" label="Reload" icon="pi pi-refresh" (click)="store.reload()"></button>
+    </div>
+
+    @if (store.isLoading()) {
+      <p>Loading albums...</p>
+    }
+
+    @if (store.isError()) {
+      <p class="text-red-500">Error: {{ store.error()?.message }}</p>
+    }
+
+    @if (store.isResolved()) {
+      <div>Number of albums: {{ store.state().albums.length }}</div>
+      <div class="flex flex-col gap-2">
+        <div *ngFor="let a of store.state().albums; trackBy: trackById" class="border p-2 flex gap-2 items-center">
+          <input class="border p-1 flex-1" [(ngModel)]="a.title" name="title-{{a.id}}" (blur)="updateAlbum(a)" />
+          <button pButton type="button" icon="pi pi-trash" severity="danger" (click)="deleteAlbum(a.id)"></button>
+        </div>
+      </div>
+    }
+  `
+})
+export class AlbumsCrudComponent {
+  readonly store: AlbumsCrudStore = inject(ALBUMS_CRUD_STORE_TOKEN);
+  newTitle = '';
+
+  trackById = (_: number, item: Album) => item.id;
+
+  async addAlbum() {
+    const title = this.newTitle.trim();
+    if (!title) return;
+    await this.store.createAlbum({ title });
+    this.newTitle = '';
+  }
+
+  async updateAlbum(album: Album) {
+    await this.store.updateAlbum(album);
+  }
+
+  async deleteAlbum(id: number) {
+    await this.store.deleteAlbum(id);
+  }
+}


### PR DESCRIPTION
## Summary
- add a new Albums CRUD demo in the playground using FeatureStore
- wire the demo into the router and sidebar
- mention new route in README

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npx nx test` *(fails: EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_683ea0d20f008330af6f3c107292fe1b