### PR TITLE
Add TTL pause handling

### DIFF
--- a/libs/smz-store/src/lib/feature-store/feature-store.ts
+++ b/libs/smz-store/src/lib/feature-store/feature-store.ts
@@ -29,7 +29,17 @@ export abstract class FeatureStore<T> extends GlobalStore<T> implements OnDestro
   resumeTtl(): void {
     this.logger.debug(`resuming TTL`);
     this._ttlPaused = false;
-    this._scheduleTtlReload?.();
+    if (this.isResolved()) {
+      this._scheduleTtlReload();
+    }
+  }
+
+  protected override _scheduleTtlReload(): void {
+    if (this._ttlPaused) {
+      this.logger.debug(`TTL paused, skipping reload scheduling`);
+      return;
+    }
+    super._scheduleTtlReload();
   }
 
 }

--- a/tests/smz-store/src/stores/feature-store.spec.ts
+++ b/tests/smz-store/src/stores/feature-store.spec.ts
@@ -1,0 +1,43 @@
+import { TestBed } from '@angular/core/testing';
+import { Injectable } from '@angular/core';
+import { GenericFeatureStore } from '@smz-ui/store';
+import { vi } from 'vitest';
+
+interface TestState {
+  count: number;
+}
+
+@Injectable()
+class TestFeatureStore extends GenericFeatureStore<TestState> {
+  constructor() {
+    super({
+      scopeName: 'ttl-store',
+      initialState: { count: 0 },
+      loaderFn: () => Promise.resolve({ count: 1 }),
+      ttlMs: 1000,
+    });
+  }
+}
+
+describe('FeatureStore TTL pause', () => {
+  let store: TestFeatureStore;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [TestFeatureStore],
+    });
+    store = TestBed.inject(TestFeatureStore);
+  });
+
+  it('should not create TTL timer while paused', async () => {
+    vi.useFakeTimers();
+    const spy = vi.spyOn(global, 'setTimeout');
+
+    store.pauseTtl();
+    await store.reload();
+    await vi.runAllTicks();
+
+    expect(spy).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- skip TTL reload scheduling in FeatureStore when paused
- resume TTL only when store is resolved
- test that pausing TTL suppresses timer creation

## Testing
- `npx vitest run -c tests/smz-store/vitest.config.mts` *(fails: npm warn Unknown env config "http-proxy")*

------
https://chatgpt.com/codex/tasks/task_b_683ea14385988330b24db6fc7985ce27