### PR TITLE
Implement store cleanup hooks

### DIFF
--- a/libs/smz-store/src/lib/state-store/plugins/auto-refresh-plugin.ts
+++ b/libs/smz-store/src/lib/state-store/plugins/auto-refresh-plugin.ts
@@ -1,4 +1,4 @@
-import { effect, Injector, PLATFORM_ID } from '@angular/core';
+import { effect, Injector, PLATFORM_ID, onCleanup } from '@angular/core';
 import { StateStore } from '../state-store';
 import { ScopedLogger } from '@smz-ui/core';
 import { isPlatformBrowser } from '@angular/common';
@@ -69,6 +69,13 @@ export function withAutoRefresh<TState>(pollingIntervalMs: number) {
           logger.debug(`[${PLUGIN_NAME}] Auto refresh timer cleared`);
         }
       }
+
+      onCleanup(() => {
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+      });
     });
   };
 }

--- a/libs/smz-store/src/lib/state-store/state-store-builder.ts
+++ b/libs/smz-store/src/lib/state-store/state-store-builder.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { EnvironmentInjector, InjectionToken, Provider } from '@angular/core';
+import { DestroyRef, EnvironmentInjector, InjectionToken, Provider } from '@angular/core';
 import { getTokenName } from '../shared/injection-token-helper';
 import { StateStore, StateStoreActions, StateStorePlugin, StateStoreSelectors } from './state-store';
 import { SmzStore, AsyncActionsStore } from './base-state-store';
@@ -49,10 +49,10 @@ export class SmzStateStoreBuilder<TState, TActions, TSelectors = any> {
   }
 
   buildProvider(token: InjectionToken<TActions>, extraDeps: any[] = []): Provider {
-    const depsArray = [EnvironmentInjector, ...this._dependencies, ...extraDeps];
+    const depsArray = [EnvironmentInjector, DestroyRef, ...this._dependencies, ...extraDeps];
     return {
       provide: token,
-      useFactory: (env: EnvironmentInjector, ...injectedDeps: any[]) => {
+      useFactory: (env: EnvironmentInjector, destroyRef: DestroyRef, ...injectedDeps: any[]) => {
         const thisName = this._name ?? getTokenName(token);
         const thisPlugins = this._plugins;
         const thisActions = this._actions;
@@ -71,6 +71,7 @@ export class SmzStateStoreBuilder<TState, TActions, TSelectors = any> {
         }
 
         const store = new GenericStateStore();
+        destroyRef.onDestroy(() => store.ngOnDestroy?.());
 
         const clientActions: TActions = {} as TActions;
         thisActions.forEach(action => action(clientActions, env, store.updateState.bind(store), store.state.bind(store)));

--- a/libs/smz-store/src/lib/state-store/state-store.ts
+++ b/libs/smz-store/src/lib/state-store/state-store.ts
@@ -146,4 +146,12 @@ export abstract class StateStore<TState> {
     this.logger.debug(`updateState`, partial);
     this.stateSignal.update((s) => ({ ...(s as any), ...partial }));
   }
+
+  /** Cleanup hook called when the store is destroyed */
+  ngOnDestroy(): void {
+    for (const entry of this.actionStatusSignals.values()) {
+      entry.effectRef.destroy();
+    }
+    this.actionStatusSignals.clear();
+  }
 }


### PR DESCRIPTION
## Summary
- destroy signals on cleanup in `StateStore`
- provide `DestroyRef` in `SmzStateStoreBuilder` and register destroy callback
- ensure timers are cleared in `withAutoRefresh`

## Testing
- `npm test` *(fails: nx not found)*

------
https://chatgpt.com/codex/tasks/task_b_684eaf5026488330abcd388a8d826cc8